### PR TITLE
Issue 2: Reorganizing bookmarks

### DIFF
--- a/src/casefileView.ts
+++ b/src/casefileView.ts
@@ -338,7 +338,11 @@ export class CasefileView implements vscode.WebviewViewProvider {
                 return false;
             }
 
-            const { mark: newParent } = getMarkPath(bookmarkForest, newParentPath).pop() || {};
+            const newParent = (
+                newParentPath.length
+                ? getMarkPath(bookmarkForest, newParentPath).pop()?.mark
+                : { children: bookmarkForest }
+            );
             if (newParent === undefined) {
                 return false;
             }

--- a/src/messageNames.ts
+++ b/src/messageNames.ts
@@ -1,3 +1,4 @@
 export const DELETE_BOOKMARK = 'deleteBookmark';
+export const MOVE_BOOKMARK = 'moveBookmark';
 export const OPEN_BOOKMARK = 'openBookmark';
 export const REQUEST_INITIAL_FILL = 'requestInitialFill';

--- a/src/views/casefile/bookmark.js
+++ b/src/views/casefile/bookmark.js
@@ -110,7 +110,7 @@ const MarkInfo = ({ bookmark, ancestors = [], dragging, drag, folding }) => {
         : <h3>{$bookmark.markText.get(bookmark)}</h3>
     );
     const controls = [
-        <span ref={drag}>
+        <span ref={drag} className="drag-handle">
             <i className="codicon codicon-gripper"></i>
         </span>
     ];

--- a/src/views/casefile/bookmark.js
+++ b/src/views/casefile/bookmark.js
@@ -102,14 +102,7 @@ const MarkInfo = ({ bookmark, ancestors = [], dragging, drag, folding }) => {
     const markContent = (
         $bookmark.file.get(bookmark)
         ? (
-            <div
-                {...vscontext({
-                    webviewArea: 'bookmark',
-                    itemPath: [...ancestors, bookmark.id],
-                    hasChildMarks: Boolean(bookmark.children?.length),
-                })}
-                onClick={openThis}
-            >
+            <div onClick={openThis}>
                 <LineRef bookmark={bookmark}/>
                 <TargetText bookmark={bookmark}/>
             </div>
@@ -129,7 +122,15 @@ const MarkInfo = ({ bookmark, ancestors = [], dragging, drag, folding }) => {
     }
 
     return (
-        <div className={`bookmark ${dragging ? 'dragging-bookmark' : ''}`} ref={drop}>
+        <div
+            className={`bookmark ${dragging ? 'dragging-bookmark' : ''}`}
+            ref={drop}
+            {...vscontext({
+                webviewArea: 'bookmark',
+                itemPath: [...ancestors, bookmark.id],
+                hasChildMarks: Boolean(bookmark.children?.length),
+            })}
+        >
             <div className="controls" ref={controlsDom}>{controls}</div>
             <div className="content" ref={contentDom}>
                 {markContent}

--- a/src/views/casefile/bookmark.js
+++ b/src/views/casefile/bookmark.js
@@ -55,7 +55,7 @@ const FOLDING_ICON_MAP = {
     'expanded': 'chevron-down',
     'default': 'blank',
 };
-const MarkInfo = ({ bookmark, ancestors = [], drag, folding }) => {
+const MarkInfo = ({ bookmark, ancestors = [], dragging, drag, folding }) => {
     // The `messagePoster`s have to be instantiated here because they `useContext`
     const showInEditor = messagePoster(OPEN_BOOKMARK);
     const moveBookmark = messagePoster(MOVE_BOOKMARK);
@@ -129,7 +129,7 @@ const MarkInfo = ({ bookmark, ancestors = [], drag, folding }) => {
     }
 
     return (
-        <div className="bookmark" ref={drop}>
+        <div className={`bookmark ${dragging ? 'dragging-bookmark' : ''}`} ref={drop}>
             <div className="controls" ref={controlsDom}>{controls}</div>
             <div className="content" ref={contentDom}>
                 {markContent}
@@ -138,7 +138,7 @@ const MarkInfo = ({ bookmark, ancestors = [], drag, folding }) => {
     );
 };
 
-const Bookmark = ({ tree: treeNode, ancestors = [] }) => {
+const Bookmark = ({ tree: treeNode, ancestors = [], ancestorDragging = false }) => {
     const nodeIdPath = [...ancestors, treeNode.id];
     const [{ isDragging }, drag, preview] = useDrag(() => ({
         type: DRAG_TYPES.BOOKMARK,
@@ -154,7 +154,12 @@ const Bookmark = ({ tree: treeNode, ancestors = [] }) => {
         : Array.from(
             $bookmark.children.getIterable(treeNode),
             subTree => (
-                <Bookmark tree={subTree} key={subTree.id} ancestors={nodeIdPath}/>
+                <Bookmark
+                    tree={subTree}
+                    key={subTree.id}
+                    ancestors={nodeIdPath}
+                    ancestorDragging={ancestorDragging || isDragging}
+                />
             )
         )
     );
@@ -171,6 +176,7 @@ const Bookmark = ({ tree: treeNode, ancestors = [] }) => {
         <div ref={preview} className="bookmark-tree">
             <MarkInfo
                 bookmark={omit(treeNode, ['children'])}
+                dragging={ancestorDragging || isDragging}
                 {...{ ancestors, drag, folding }}
             />
             {...shownChildren}

--- a/src/views/casefile/bookmark.js
+++ b/src/views/casefile/bookmark.js
@@ -20,7 +20,7 @@ const TargetText = ({ bookmark }) => (
     </div>
 );
 
-const insertionFromClientCoords = ({x, y}, { controls, content }) => {
+export const insertionFromClientCoords = ({x, y}, { controls, content }) => {
     try {
         if (controls.left <= x && x < controls.right) {
             const midLineY = (controls.top + controls.bottom) / 2;

--- a/src/views/casefile/view.css
+++ b/src/views/casefile/view.css
@@ -25,6 +25,10 @@
     grid-template-areas: "controls content";
 }
 
+.dragging-bookmark {
+    opacity: 0.5;
+}
+
 .bookmark > .controls {
     /* grid-area: controls; */
     grid-column: controls-start / controls-end;

--- a/src/views/casefile/view.css
+++ b/src/views/casefile/view.css
@@ -23,6 +23,12 @@
     display: grid;
     grid-template-columns: [gutter-start] 1.5em [gutter-end content-start] auto [content-end];
     grid-template-areas: "controls content";
+    cursor: default;
+}
+
+.bookmark:hover {
+    background-color: var(--vscode-list-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
 }
 
 .dragging-bookmark {
@@ -30,15 +36,17 @@
 }
 
 .bookmark > .controls {
-    /* grid-area: controls; */
     grid-column: controls-start / controls-end;
     align-self: center;
     display: flex;
     flex-direction: column;
 }
 
+.bookmark > .controls .drag-handle {
+    cursor: grab;
+}
+
 .bookmark > .content {
-    /* grid-area: node-content; */
     grid-column: content-start / content-end;
     margin-bottom: 0.4em;
 }
@@ -60,17 +68,23 @@
     height: 6px;
     pointer-events: none;
     border-radius: 3px;
-    background-color: white;
+    background-color: var(--vscode-list-highlightForeground);
     opacity: 0.5;
 }
 
 .casefile-ui .bookmark-trash {
     display: flex;
     align-items: self-start;
-    background-color: darkred;
+    background-color: var(--vscode-list-inactiveSelectionBackground);
+    color: var(--vscode-list-inactiveSelectionForeground);
     padding: 3px;
     position: relative;
     z-index: 40;
+}
+
+.casefile-ui .bookmark-trash[data-drop-status="current-target"] {
+    background-color: var(--vscode-diffEditor-removedTextBackground);
+    color: var(--vscode-diffEditor-removedTextForeground);
 }
 
 .casefile-ui .bookmark-trash div {

--- a/src/views/casefile/view.css
+++ b/src/views/casefile/view.css
@@ -6,25 +6,37 @@
     font-weight: bold;
 }
 
-.bookmark {
+.bookmark-tree {
     display: grid;
     grid-template-columns: [gutter-start] 1.5em [gutter-end content-start] auto [content-end];
     grid-template-rows: [self-start] auto [self-end children-start] auto [children-end];
-    grid-template-areas:    "controls node-content"
+    grid-template-areas:    "bookmark bookmark"
                             "indent   children";
     /* When nested, appears in "children" */
     grid-area: children;
 }
 
+.bookmark-tree > .bookmark {
+    grid-area: bookmark;
+}
+
+.bookmark {
+    display: grid;
+    grid-template-columns: [gutter-start] 1.5em [gutter-end content-start] auto [content-end];
+    grid-template-areas: "controls content";
+}
+
 .bookmark > .controls {
-    grid-area: controls;
+    /* grid-area: controls; */
+    grid-column: controls-start / controls-end;
     align-self: center;
     display: flex;
     flex-direction: column;
 }
 
 .bookmark > .content {
-    grid-area: node-content;
+    /* grid-area: node-content; */
+    grid-column: content-start / content-end;
     margin-bottom: 0.4em;
 }
 

--- a/src/views/casefile/view.css
+++ b/src/views/casefile/view.css
@@ -49,6 +49,17 @@
     background-color: var(--vscode-sideBar-background);
 }
 
+.casefile-ui .drop-shadow {
+    position: fixed;
+    top: -20px;
+    z-index: 50;
+    height: 6px;
+    pointer-events: none;
+    border-radius: 3px;
+    background-color: white;
+    opacity: 0.5;
+}
+
 .casefile-ui .bookmark-trash {
     display: flex;
     align-items: self-start;

--- a/src/views/casefile/view.css
+++ b/src/views/casefile/view.css
@@ -9,11 +9,10 @@
 .bookmark-tree {
     display: grid;
     grid-template-columns: [gutter-start] 1.5em [gutter-end content-start] auto [content-end];
-    grid-template-rows: [self-start] auto [self-end children-start] auto [children-end];
-    grid-template-areas:    "bookmark bookmark"
-                            "indent   children";
-    /* When nested, appears in "children" */
-    grid-area: children;
+    grid-template-rows: [self-start] auto [self-end] auto;
+    grid-template-areas:    "bookmark bookmark";
+    /* When nested, appears in "content" column-span */
+    grid-column: content;
 }
 
 .bookmark-tree > .bookmark {

--- a/src/views/casefile/view.js
+++ b/src/views/casefile/view.js
@@ -30,15 +30,18 @@ const RequestInitialData = ({ children }) => {
 
 const Trash = () => {
     const deleteBookmark = messagePoster(DELETE_BOOKMARK);
-    const [, trashDrop] = useDrop(() => ({
+    const [{ cursorHovering }, trashDrop] = useDrop(() => ({
         accept: [DRAG_TYPES.BOOKMARK],
         drop: ({ itemPath }) => {
             deleteBookmark({ itemPath });
         },
+        collect: (monitor) => ({
+            cursorHovering: monitor.isOver({ shallow: true }),
+        }),
     }));
 
     return (
-        <div className="bookmark-trash" ref={trashDrop}>
+        <div className="bookmark-trash" ref={trashDrop} data-drop-status={cursorHovering ? 'current-target' : 'none'}>
             <div><i className="codicon codicon-trash"></i><span> Remove</span></div>
         </div>
     );

--- a/src/views/casefile/view.js
+++ b/src/views/casefile/view.js
@@ -120,18 +120,33 @@ const Bookmarks = ({ state }) => {
         if (!dropShadowElt) {
             return;
         }
-        // Obtain bookmark from *dragHover* with `document.elementFromPoint()` and traverse up to `.bookmark` element
+        // Obtain bookmark from *dragHover* with `document.elementFromPoint()`
+        // and traverse up to `.bookmark` element
         const bookmarkElt = dragHover && getDropTargetElement(dragHover);
         let shadowStyleAttrs = { top: '' };
-        if (dragHover && bookmarkElt) {
-            // Obtain client-coord DomRects for the `.controls` and `.content` children of the bookmark element and the overall bookmark
-            const elementRects = getBookmarkRects(bookmarkElt);
-            // Compute target shadow location
-            shadowStyleAttrs = computeDestShadowLocation({
-                dragHover,
-                elementRects,
-                shadowHeight: dropShadowElt.offsetHeight,
-            });
+        const dragItem = (
+            (dragMonitor.getItemType() === DRAG_TYPES.BOOKMARK)
+            ? dragMonitor.getItem()
+            : null
+        );
+        if (dragHover && bookmarkElt && dragItem) {
+            // Check if dragItem.id is present in itemPath of bookmarkElt -- 
+            // and do not position drop shadow if so
+            const draggedItemPathIndex = JSON.parse(
+                bookmarkElt.dataset?.vscodeContext || '{}'
+            )?.itemPath.indexOf(dragItem.id);
+            if (draggedItemPathIndex < 0) {
+                // Obtain client-coord DomRects for the `.controls` and
+                // `.content` children of the bookmark element and the
+                // overall bookmark
+                const elementRects = getBookmarkRects(bookmarkElt);
+                // Compute target shadow location
+                shadowStyleAttrs = computeDestShadowLocation({
+                    dragHover,
+                    elementRects,
+                    shadowHeight: dropShadowElt.offsetHeight,
+                });
+            }
         }
         // Move the shadow to the location
         Object.assign(dropShadowElt.style, shadowStyleAttrs);

--- a/src/views/casefile/view.js
+++ b/src/views/casefile/view.js
@@ -1,17 +1,16 @@
 import { render } from 'preact';
 import React from 'preact/compat'; // This just makes VSCode's Intellisense happy
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { DndProvider, useDrop } from 'react-dnd';
+import { DndProvider, useDragDropManager, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { applicationOfMessagesToState } from './receivedMessages';
-import { thru } from 'lodash';
 import { EnterAndExitTransition } from '@devclusters/fluency';
 import { $casefile } from '../../datumPlans';
-import Bookmark from './bookmark';
+import Bookmark, { insertionFromClientCoords } from './bookmark';
 import "./view.css";
 import { MessagePasser, messagePoster } from './messageSending';
 import { DRAG_TYPES } from './constants';
-import { vscontext, NO_STD_CMENU_ENTRIES } from '../helpers';
+import { vscontext, NO_STD_CMENU_ENTRIES, when } from '../helpers';
 import { DELETE_BOOKMARK, REQUEST_INITIAL_FILL } from '../../messageNames';
 
 const vscode = acquireVsCodeApi();
@@ -27,29 +26,6 @@ const RequestInitialData = ({ children }) => {
         requestInitialData({});
     }, []);
     return <>{ children }</>;
-};
-
-const useDragging = () => {
-    const [dragging, setDragging] = useState(false);
-    const dragWatcher = useRef();
-    useEffect(() => {
-        const node = dragWatcher.current;
-        const listeners = [
-            ['dragstart',   () => { setDragging(true); },   true],
-            ['dragend',     () => { setDragging(false); },  false],
-        ];
-        for (const listenArgs of listeners) {
-            node.addEventListener(...listenArgs);
-        }
-        // Remove listeners when unmounted
-        return () => {
-            for (const listenArgs of listeners) {
-                node.removeEventListener(...listenArgs);
-            }
-        };
-    }, []);
-
-    return [dragging, dragWatcher];
 };
 
 const Trash = () => {
@@ -68,8 +44,119 @@ const Trash = () => {
     );
 };
 
+const getDropTargetElement = ({x, y}) => {
+    const elements = document.elementsFromPoint(x, y);
+    for (let i = 0; i < elements.length; i++) {
+        const element = elements[i].closest('.bookmark');
+        if (element) {
+            return element;
+        }
+    }
+};
+
+const getBookmarkRects = (bookmarkElt) => {
+    const childrenByClass = {};
+    for (let i = bookmarkElt.children.length - 1; i >= 0 ; i--) {
+        const child = bookmarkElt.children[i];
+        for (let j = 0; j < child.classList.length; j++) {
+            const className = child.classList[j];
+            childrenByClass[className] = child;
+        }
+    }
+    const childRects = Object.fromEntries([
+        'controls',
+        'content',
+    ].map((className) => [
+        className,
+        childrenByClass[className]?.getBoundingClientRect?.()
+    ]));
+
+    return {
+        ...childRects,
+        bookmark: bookmarkElt.getBoundingClientRect(),
+    };
+};
+
+const computeDestShadowLocation = ({ dragHover, elementRects, shadowHeight }) => {
+    // Use *insertionFromClientCoords* to determine where on the target bookmark the shadow should be placed
+    const insertAs = insertionFromClientCoords(dragHover, elementRects);
+    const styleAttrs = ({ xParams: { left, width }, y }) => ({
+        left: left + 'px',
+        top: (y - shadowHeight / 2) + 'px',
+        width: width + 'px',
+        right: '',
+        bottom: '',
+    });
+    if (insertAs?.siblingBefore) {
+        return styleAttrs({
+            xParams: elementRects.bookmark,
+            y: elementRects.bookmark.top,
+        });
+    } else if (insertAs?.siblingAfter) {
+        return styleAttrs({
+            xParams: elementRects.bookmark,
+            // May want to change this to the bottom of the closest ".bookmark-tree"
+            y: elementRects.bookmark.bottom,
+        });
+    } else if (insertAs?.child) {
+        return styleAttrs({
+            xParams: elementRects.content,
+            y: elementRects.bookmark.bottom,
+        });
+    }
+};
+
+const Bookmarks = ({ state }) => {
+    const [ dragging, setDragging ] = useState(false);
+    const dragDropManager = useDragDropManager();
+    const dragMonitor = dragDropManager.getMonitor();
+    useEffect(() => dragMonitor.subscribeToStateChange(() => {
+        setDragging(dragMonitor.isDragging());
+    }), [dragMonitor]);
+    const dropShadowRef = useRef(null);
+    useEffect(() => dragMonitor.subscribeToOffsetChange(() => {
+        const dragHover = dragMonitor.getClientOffset();
+        const dropShadowElt = dropShadowRef.current;
+        if (!dropShadowElt) {
+            return;
+        }
+        // Obtain bookmark from *dragHover* with `document.elementFromPoint()` and traverse up to `.bookmark` element
+        const bookmarkElt = dragHover && getDropTargetElement(dragHover);
+        let shadowStyleAttrs = { top: '' };
+        if (dragHover && bookmarkElt) {
+            // Obtain client-coord DomRects for the `.controls` and `.content` children of the bookmark element and the overall bookmark
+            const elementRects = getBookmarkRects(bookmarkElt);
+            // Compute target shadow location
+            shadowStyleAttrs = computeDestShadowLocation({
+                dragHover,
+                elementRects,
+                shadowHeight: dropShadowElt.offsetHeight,
+            });
+        }
+        // Move the shadow to the location
+        Object.assign(dropShadowElt.style, shadowStyleAttrs);
+    }), [dragMonitor]);
+
+    return <div className="casefile-ui" {...vscontext(NO_STD_CMENU_ENTRIES)}>
+        <div className="bookmarks-forest">
+            {...Array.from(
+                $casefile.bookmarks.getIterable(state),
+                bookmark => <Bookmark tree={bookmark} key={bookmark.id}/>
+            )}
+        </div>
+        { when(dragging, <div className="drop-shadow" ref={dropShadowRef} />) }
+        <EnterAndExitTransition
+            triggerEnter={dragging}
+            triggerExit={!dragging}
+            transitionNameEnter='slideInDown'
+            transitionNameExit='slideOutUp'
+        >
+            <Trash/>
+        </EnterAndExitTransition>
+    </div>;
+};
+
 const View = () => {
-    const [dragging, dragWatcherRef] = useDragging();
     const stateManagement = useState({}), [ state ] = stateManagement;
 
     return (
@@ -78,22 +165,7 @@ const View = () => {
                 <BindMessageHandling {...{ stateManagement }} />
             </RequestInitialData>
             <DndProvider backend={HTML5Backend}>
-                <div className="casefile-ui" ref={dragWatcherRef} {...vscontext(NO_STD_CMENU_ENTRIES)}>
-                    <div className="bookmarks-forest">
-                        {...Array.from(
-                            $casefile.bookmarks.getIterable(state),
-                            bookmark => <Bookmark tree={bookmark} key={bookmark.id}/>
-                        )}
-                    </div>
-                    <EnterAndExitTransition
-                        triggerEnter={dragging}
-                        triggerExit={!dragging}
-                        transitionNameEnter='slideInDown'
-                        transitionNameExit='slideOutUp'
-                    >
-                        <Trash/>
-                    </EnterAndExitTransition>
-                </div>
+                <Bookmarks {...{ state }}/>
             </DndProvider>
         </MessagePasser>
     );

--- a/src/views/casefile/view.js
+++ b/src/views/casefile/view.js
@@ -70,10 +70,12 @@ const getBookmarkRects = (bookmarkElt) => {
         className,
         childrenByClass[className]?.getBoundingClientRect?.()
     ]));
+    const treeElt = bookmarkElt.closest('.bookmark-tree');
 
     return {
         ...childRects,
         bookmark: bookmarkElt.getBoundingClientRect(),
+        tree: treeElt.getBoundingClientRect(),
     };
 };
 
@@ -96,7 +98,7 @@ const computeDestShadowLocation = ({ dragHover, elementRects, shadowHeight }) =>
         return styleAttrs({
             xParams: elementRects.bookmark,
             // May want to change this to the bottom of the closest ".bookmark-tree"
-            y: elementRects.bookmark.bottom,
+            y: elementRects.tree.bottom,
         });
     } else if (insertAs?.child) {
         return styleAttrs({

--- a/src/views/helpers.js
+++ b/src/views/helpers.js
@@ -9,3 +9,7 @@ export function vscontext(value) {
 export const NO_STD_CMENU_ENTRIES = Object.freeze(
     {'preventDefaultContextMenuItems': true}
 );
+
+export function when(cond, output) {
+    return cond ? output : null;
+}


### PR DESCRIPTION
This set of commits allows bookmarks to be reorganized via drag-and-drop to a new location.  The new location for the bookmark is dependent on where on a target bookmark the dragged bookmark is dropped: it can be previous sibling, first child, or next sibling; this is indicated to the user with a "drop shadow" bar.