### PR TITLE
Show shared casefiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       },
       "casefile-fetch-shared":{
         "description": "Fetch casefiles from the selected peer",
-        "default": "repo-pull"
+        "default": "refresh"
       },
       "casefile-select-sharing-peer":{
         "description": "Select a peer for sharing casefiles",
@@ -64,13 +64,13 @@
         "command": "codeCasefile.fetchCasefilesFromPeer",
         "title": "Fetch casefiles from the selected peer",
         "category": "Casefile",
-        "icon": "${casefile-fetch-shared}"
+        "icon": "$(casefile-fetch-shared)"
       },
       {
         "command": "codeCasefile.selectSharingPeer",
         "title": "Select peer for sharing",
         "category": "Casefile",
-        "icon": "${casefile-select-sharing-peer"
+        "icon": "$(casefile-select-sharing-peer)"
       }
     ],
     "menus": {
@@ -89,6 +89,11 @@
           "command": "codeCasefile.selectSharingPeer",
           "when": "view == 'codeCasefile.sharedCasefilesView'",
           "group": "1_modification"
+        },
+        {
+          "command": "codeCasefile.fetchCasefilesFromPeer",
+          "when": "view == 'codeCasefile.sharedCasefilesView' && codeCasefile.peerEstablished",
+          "group": "navigation"
         }
       ],
       "webview/context": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       "casefile-fetch-shared":{
         "description": "Fetch casefiles from the selected peer",
         "default": "repo-pull"
+      },
+      "casefile-select-sharing-peer":{
+        "description": "Select a peer for sharing casefiles",
+        "default": "remote"
       }
     },
     "commands": [
@@ -61,6 +65,12 @@
         "title": "Fetch casefiles from the selected peer",
         "category": "Casefile",
         "icon": "${casefile-fetch-shared}"
+      },
+      {
+        "command": "codeCasefile.selectSharingPeer",
+        "title": "Select peer for sharing",
+        "category": "Casefile",
+        "icon": "${casefile-select-sharing-peer"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
         {
           "command": "codeCasefile.deleteAllBookmarks",
           "when": "view == 'codeCasefile.casefileView'"
+        },
+        {
+          "command": "codeCasefile.selectSharingPeer",
+          "when": "view == 'codeCasefile.sharedCasefilesView'",
+          "group": "1_modification"
         }
       ],
       "webview/context": [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
       "casefile-delete-all-bookmarks": {
         "description": "Delete all bookmarks from the current casefile",
         "default": "clear-all"
+      },
+      "casefile-fetch-shared":{
+        "description": "Fetch casefiles from the selected peer",
+        "default": "repo-pull"
       }
     },
     "commands": [
@@ -51,6 +55,12 @@
         "title": "Delete all bookmarks from current casefile",
         "category": "Casefile",
         "icon": "$(casefile-delete-all-bookmarks)"
+      },
+      {
+        "command": "codeCasefile.fetchCasefilesFromPeer",
+        "title": "Fetch casefiles from the selected peer",
+        "category": "Casefile",
+        "icon": "${casefile-fetch-shared}"
       }
     ],
     "menus": {
@@ -79,6 +89,11 @@
           "type": "webview",
           "id": "codeCasefile.casefileView",
           "name": "Current Casefile"
+        },
+        {
+          "id": "codeCasefile.sharedCasefilesView",
+          "name": "Shared Casefiles",
+          "visibility": "collapsed"
         }
       ]
     }

--- a/src/CasefileSharingState.ts
+++ b/src/CasefileSharingState.ts
@@ -1,0 +1,6 @@
+import { CasefileGroup } from "git-casefile";
+
+export type CasefileSharingState = {
+    knownCasefiles?: CasefileGroup[],
+    peer?: { folder: string, remote: string },
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,18 @@
 import * as vscode from 'vscode';
 import { CasefileView } from './casefileView';
 import GitCasefile from './services/gitCasefile';
-import Services from './services';
+import Services, { Persistence } from './services';
 import { Casefile } from './Casefile';
 import { debug } from './debugLog';
+import { CasefileSharingState } from './CasefileSharingState';
+import { SharedCasefilesViewManager } from './sharedCasefilesView';
 
-const PERSISTENT_STATE_PROPERTY = 'casefile';
+const CASEFILE_PERSISTENCE_PROPERTY = 'casefile';
+const SHARING_PERSISTENCE_PROPERTY = 'sharing';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 	const subscribe = context.subscriptions.push.bind(context.subscriptions);
 
 	const services = new Services({
@@ -20,9 +23,10 @@ export function activate(context: vscode.ExtensionContext) {
 			)
 			|| []
 		),
-		getCurrentForest: () => context.workspaceState.get<Casefile>(PERSISTENT_STATE_PROPERTY) ?? {},
-		setCurrentForest: (casefile) => context.workspaceState.update(PERSISTENT_STATE_PROPERTY, casefile),
+		forestPersistence: workspaceStatePersister(context, CASEFILE_PERSISTENCE_PROPERTY, () => ({})),
+		sharingStatePersistence: workspaceStatePersister(context, SHARING_PERSISTENCE_PROPERTY, () => ({})),
 	});
+	subscribe(services);
 
 	subscribe(vscode.workspace.onDidChangeConfiguration(e => {
 		if (e.affectsConfiguration('casefile.externalTools')) {
@@ -34,6 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}));
 
 	const casefileView = new CasefileView(context.extensionUri, services);
+	subscribe(casefileView);
 	subscribe(vscode.window.registerWebviewPanelSerializer(
 		CasefileView.viewType,
 		new CasefileView.PanelSerializer()
@@ -42,6 +47,10 @@ export function activate(context: vscode.ExtensionContext) {
 		CasefileView.viewType,
 		casefileView
 	));
+
+	const sharingManager = new SharedCasefilesViewManager(services);
+	subscribe(sharingManager);
+	await sharingManager.loadPeerList();
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
@@ -55,16 +64,32 @@ export function activate(context: vscode.ExtensionContext) {
 		});
 	}));
 
-	subscribe(
-		vscode.commands.registerCommand('codeCasefile.deleteBookmark', ({ itemPath }) => {
+	subscribe(...Object.entries({
+
+		deleteAllBookmarks: () => {
+			casefileView.deleteAllBookmarks();
+		},
+
+		deleteBookmark: ({ itemPath }: { itemPath: string[] }) => {
 			debug("deleteBookmark command executed: %o", itemPath);
 			casefileView.deleteBookmark(itemPath);
-		}),
-		vscode.commands.registerCommand('codeCasefile.deleteAllBookmarks', () => {
-			casefileView.deleteAllBookmarks();
-		}),
-	);
+		},
+
+		fetchCasefilesFromPeer: async () => {
+			debug("Fetching casefile from peer");
+			await sharingManager.fetchFromCurrentPeer();
+		},
+
+	}).map(([name, handler]) => vscode.commands.registerCommand('codeCasefile.' + name, handler)));
 }
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
+function workspaceStatePersister<T>(context: vscode.ExtensionContext, key: string, makeDefault: () => T): Persistence<T> {
+	return [
+		() => context.workspaceState.get<T>(key) ?? makeDefault(),
+		(state) => context.workspaceState.update(key, state)
+	];
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,6 +80,11 @@ export async function activate(context: vscode.ExtensionContext) {
 			await sharingManager.fetchFromCurrentPeer();
 		},
 
+		selectSharingPeer: async () => {
+			debug("Asking user to select sharing peer");
+			await sharingManager.promptUserForPeer();
+		},
+
 	}).map(([name, handler]) => vscode.commands.registerCommand('codeCasefile.' + name, handler)));
 }
 

--- a/src/services/git-casefile.d.ts
+++ b/src/services/git-casefile.d.ts
@@ -2,6 +2,7 @@ declare module 'git-casefile' {
     export class CasefileKeeper {
         constructor(kwargs?: { toolOptions: ToolOptions, editor?: {} });
         bookmarks: BookmarkFacilitator;
+        gitOps: GitInteraction;
         workingDir?: string;
     }
 
@@ -9,8 +10,22 @@ declare module 'git-casefile' {
 
     };
 
+    type CasefileGroup = {
+        name: string,
+        instances: {
+            path: string
+        }[],
+    };
+
     class BookmarkFacilitator {
         currentLocation(bookmark: Bookmark): any;
+    }
+
+    class GitInteraction {
+        fetchSharedCasefilesFromRemote(remote: string): Promise<void>;
+        getCasefileAuthors(path: string): Promise<{path: string, authors: string[]}>;
+        getListOfCasefiles(): Promise<CasefileGroup[]>;
+        getListOfRemotes(): Promise<string[]>;
     }
 
     type Bookmark = any;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,22 +1,48 @@
 import { CasefileKeeper } from "git-casefile";
 import GitCasefile from "./gitCasefile";
-import { WorkspaceConfiguration } from "vscode";
+import { Event, EventEmitter, WorkspaceConfiguration } from "vscode";
 import type { Casefile } from "../Casefile";
+import { CasefileSharingState } from "../CasefileSharingState";
+import { thru } from "lodash";
+
+export type Persistence<T> = [
+    /* load */ () => T,
+    /* save */ (value: T) => Thenable<void>
+];
 
 type ServicesConfig = {
     getConfig: () => WorkspaceConfiguration,
     getWorkdirs: () => string[],
-    getCurrentForest: () => Casefile,
-    setCurrentForest: (casefile: Casefile) => void,
+    forestPersistence: Persistence<Casefile>,
+    sharingStatePersistence: Persistence<CasefileSharingState>,
 };
 
 export default class Services {
     casefile: GitCasefile;
+    private _forestChanged = new EventEmitter<Casefile>();
     getCurrentForest: () => Casefile;
-    setCurrentForest: (casefile: Casefile) => void;
+    setCurrentForest: (casefile: Casefile) => Thenable<void>;
+    getSharingState: () => CasefileSharingState;
+    setSharingState: (state: CasefileSharingState) => Thenable<void>;
+
     constructor(config: ServicesConfig) {
         this.casefile = new GitCasefile(config);
-        this.getCurrentForest = config.getCurrentForest;
-        this.setCurrentForest = config.setCurrentForest;
+        this.getCurrentForest = config.forestPersistence[0];
+        this.setCurrentForest = thru(
+            config.forestPersistence[1],
+            (setter) => (casefile: Casefile) => (setter(casefile).then(() => {
+                this._forestChanged.fire(casefile);
+            }))
+        );
+        this.getSharingState = config.sharingStatePersistence[0];
+        this.setSharingState = config.sharingStatePersistence[1];
+    }
+
+    dispose() {
+        this._forestChanged.dispose();
+    }
+
+    get onForestChange(): Event<Casefile> {
+        return this._forestChanged.event;
     }
 }

--- a/src/sharedCasefilesView.ts
+++ b/src/sharedCasefilesView.ts
@@ -6,7 +6,7 @@ import { cloneDeep, tap, thru } from 'lodash';
 import { basename, dirname } from 'path';
 import { CasefileSharingState } from './CasefileSharingState';
 import { CasefileGroup, CasefileKeeper } from 'git-casefile';
-import { deiconed } from './vscodeUtils';
+import { deiconed, setContext } from './vscodeUtils';
 
 const PICK_PAYLOAD = Symbol('payload');
 
@@ -214,6 +214,7 @@ export class SharedCasefilesViewManager {
                 }
             }
         );
+        setContext('peerEstablished', Boolean(peer));
     }
 
     getEffectivePeer(): CasefileStore | null {
@@ -309,7 +310,7 @@ export class SharedCasefilesViewManager {
             );
             return;
         }
-        debug("Fetching from %O", peer);
+        debug("Fetching from %o", peer);
 
         await this._modifySharingState((state) => {
             if (!state.peer) {

--- a/src/sharedCasefilesView.ts
+++ b/src/sharedCasefilesView.ts
@@ -1,0 +1,397 @@
+import * as vscode from 'vscode';
+import { CancellationToken, Command, Disposable, EventEmitter, ProviderResult, TreeDataProvider, TreeItem, TreeItemCollapsibleState as FoldState } from "vscode";
+import Services from "./services";
+import { debug } from './debugLog';
+import { cloneDeep, tap, thru } from 'lodash';
+import { basename, dirname } from 'path';
+import { CasefileSharingState } from './CasefileSharingState';
+import { CasefileGroup, CasefileKeeper } from 'git-casefile';
+
+interface TreeItemSource {
+    renderTreeItem(): TreeItem;
+    getChildren(): ProviderResult<TreeItemSource[]>;
+}
+
+type CasefileStore = {
+    folder: string,
+    remote: string,
+};
+
+type CasefileInstanceMetadata = {
+    path: string,
+    authors?: string[],
+};
+
+class StoreSelector implements TreeItemSource {
+    private _treeItem: vscode.TreeItem;
+
+    constructor() {
+        this._treeItem = new TreeItem(
+            `Select sharing peer to display available casefiles`
+
+        );
+        this._treeItem.iconPath = new vscode.ThemeIcon('inspect');
+        this._treeItem.command = {
+            command: "codeCasefile.selectSharingPeer",
+            title: "Select sharing peer",
+        };
+    }
+
+    renderTreeItem(): vscode.TreeItem {
+        return this._treeItem;
+    }
+
+    getChildren(): vscode.ProviderResult<TreeItemSource[]> {
+        return [];
+    }
+}
+
+class LibraryLoader implements TreeItemSource {
+    private _treeItem: vscode.TreeItem;
+
+    constructor() {
+        this._treeItem = new TreeItem(
+            `Fetch the shared casefiles list`
+        );
+        this._treeItem.iconPath = new vscode.ThemeIcon('inspect');
+        this._treeItem.command = {
+            command: "codeCasefile.fetchCasefilesFromPeer",
+            title: "Select sharing peer",
+        };
+    }
+
+    renderTreeItem(): vscode.TreeItem {
+        return this._treeItem;
+    }
+
+    getChildren(): vscode.ProviderResult<TreeItemSource[]> {
+        return [];
+    }
+}
+
+class CasefileNameGroup implements TreeItemSource {
+    private _treeItem: vscode.TreeItem;
+    private _instances: CasefileInstance[] = [];
+    constructor(
+        private readonly _manager: SharedCasefilesViewManager,
+        private readonly group: CasefileGroup,
+    ) {
+        this._treeItem = new TreeItem(this.group.name);
+        this._treeItem.id = `CasefileGroup ${this.group.name}`;
+        this._treeItem.iconPath = new vscode.ThemeIcon('bookmark');
+        if (this.group.instances.length > 1) {
+            this._treeItem.collapsibleState = FoldState.Expanded;
+        }
+    }
+    renderTreeItem(): TreeItem {
+        return this._treeItem;
+    }
+    async getChildren(): Promise<TreeItemSource[]> {
+        await Promise.all(this.group.instances.map(async (instance) => {
+            await this._manager.includeAuthors(instance);
+        }));
+        return this._instances;
+    }
+}
+
+class CasefileInstance implements TreeItemSource {
+    private _treeItem: vscode.TreeItem;
+    constructor(instance: { path: string, authors: string[] }) {
+        this._treeItem = new TreeItem("");
+    }
+    renderTreeItem(): vscode.TreeItem {
+        throw new Error('Method not implemented.');
+    }
+    getChildren(): vscode.ProviderResult<TreeItemSource[]> {
+        throw new Error('Method not implemented.');
+    }
+}
+
+class CasefileLibrary implements TreeDataProvider<TreeItemSource> {
+    onDidChangeTreeData: vscode.Event<void | TreeItemSource | TreeItemSource[] | null | undefined>;
+
+    constructor(
+        private readonly _manager: SharedCasefilesViewManager,
+        options: {
+            dataChangedEvent: vscode.Event<void | TreeItemSource | TreeItemSource[]>,
+        }
+    ) {
+        this.onDidChangeTreeData = options.dataChangedEvent;
+    }
+    dispose() {}
+
+    getTreeItem(element: TreeItemSource): Thenable<vscode.TreeItem> {
+        return Promise.resolve(element.renderTreeItem());
+    }
+    async getChildren(element?: TreeItemSource | undefined): Promise<TreeItemSource[] | null | undefined> {
+        if (element) {
+            return element.getChildren();
+        }
+
+        if (!this._manager.peerList) {
+            await this._manager.loadPeerList();
+        }
+        if (!this._manager.getEffectivePeer()) {
+            return [new StoreSelector()];
+        }
+        const knownCasefiles = this._manager.knownCasefiles;
+        if (!knownCasefiles) {
+            return [new LibraryLoader()];
+        }
+        return knownCasefiles.map(
+            (casefileGroup) => new CasefileNameGroup(this._manager, casefileGroup)
+        );
+    }
+    // getParent?(element: SharedCasefile): vscode.ProviderResult<SharedCasefile> {
+    //     throw new Error('Method not implemented.');
+    // }
+    // resolveTreeItem?(item: vscode.TreeItem, element: SharedCasefile, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TreeItem> {
+    //     throw new Error('Method not implemented.');
+    // }
+
+};
+
+export class SharedCasefilesViewManager {
+    public static readonly viewType = 'codeCasefile.sharedCasefilesView';
+
+    private readonly _disposables = new Set<Disposable>();
+    private _currentLibrary: CasefileLibrary;
+    private _peerList: CasefileStore[] | null = null;
+    private _sharingState: CasefileSharingState;
+    private _sharingView: vscode.TreeView<TreeItemSource>;
+    private _stateChange = new EventEmitter<void | TreeItemSource | TreeItemSource[]>();
+
+    constructor(
+        private readonly _services: Services,
+    ) {
+        this._sharingState = this._services.getSharingState();
+        const viewId = SharedCasefilesViewManager.viewType;
+        this._currentLibrary = this._subscribe(new CasefileLibrary(this, {
+            dataChangedEvent: this._stateChange.event,
+        }));
+        this._sharingView = vscode.window.createTreeView(viewId, {
+            treeDataProvider: this._currentLibrary,
+        });
+        this._setViewInfo();
+    }
+
+    private _subscribe<T extends Disposable>(disposable: T): T {
+        this._disposables.add(disposable);
+        return disposable;
+    }
+
+    dispose() {
+        this._disposables.forEach((disposable) => {
+            try {
+                disposable.dispose();
+            } catch (error) {
+                console.error(error);
+            }
+        });
+    }
+
+    private _setViewInfo() {
+        const peer = this.getEffectivePeer();
+
+        this._sharingView.message = undefined;
+        this._sharingView.description = thru(
+            this.getEffectivePeer(),
+            (peer) => {
+                if (peer) {
+                    const folderDesc = thru(
+                        basename(peer.folder),
+                        (folderName) => (
+                            workspaceFolderBasenameCount(folderName) > 1
+                            ? `${folderName} (${dirname(peer.folder)})`
+                            : folderName
+                        )
+                    );
+                    return `"${peer.remote}" of ${folderDesc}`;
+                }
+            }
+        );
+    }
+
+    getEffectivePeer(): CasefileStore | null {
+        if (this.peer) {
+            return this.peer;
+        }
+        const { workspaceFolders } = vscode.workspace;
+        if (!workspaceFolders) {
+            return null;
+        }
+        const localFolders = workspaceFolders.filter(
+            ({ uri }) => Boolean(uri.fsPath)
+        );
+        if (localFolders.length !== 1) {
+            return null;
+        }
+        const localFolderPath = localFolders[0].uri.fsPath;
+        if (!this._peerList || !this._peerList.find(
+            ({ folder, remote }) => (
+                remote === 'origin'
+                && folder === localFolderPath
+            )
+        )) {
+            return null;
+        }
+        return {
+            folder: localFolderPath,
+            remote: 'origin',
+        };
+    }
+
+    get peerList(): CasefileStore[] | null {
+        return this._peerList;
+    }
+
+    async loadPeerList() {
+        this._peerList = await Promise.all(this._services.casefile.keepers.map(
+            (keeper) => {
+                if (!keeper.workingDir) {
+                    return [];
+                }
+                const folder = keeper.workingDir;
+                return keeper.gitOps.getListOfRemotes().then(
+                    (remotes) => remotes.map(
+                        (remote) => ({ folder, remote })
+                    )
+                );
+            }
+        )).then((items) => items.flat());
+    }
+
+    get peer(): CasefileStore | undefined {
+        return this._sharingState.peer;
+    }
+    get knownCasefiles(): CasefileGroup[] | undefined {
+        return this._sharingState.knownCasefiles;
+    }
+
+    private _modifySharingState(fn: (state: CasefileSharingState) => (boolean | Promise<boolean>)) : Promise<boolean> {
+        const state = cloneDeep(this._sharingState);
+        return Promise.resolve()
+        .then(() => fn(state))
+        .then(
+            async (indicator) => {
+                if (indicator !== false) {
+                    await this._services.setSharingState(state);
+                    this._sharingState = state;
+                }
+                return true;
+            },
+
+            (error) => {
+                console.error(error);
+                return false;
+            }
+        );
+    }
+
+    async fetchFromCurrentPeer() {
+        const peer = this.getEffectivePeer();
+        if (!peer) {
+            console.error(
+                "code-casefile: Cannot fetch if no peer is selected or inferable",
+            );
+            return;
+        }
+        debug("Fetching from %O", peer);
+
+        await this._modifySharingState((state) => {
+            if (!state.peer) {
+                // Save the effective peer as our peer
+                state.peer = peer;
+                return true;
+            }
+            return false;
+        });
+
+        const keeper = await this._getCurrentKeeper({
+            folder: peer.folder,
+        });
+        debug("Using keeper %O", keeper);
+        if (!keeper) {
+            return;
+        }
+
+        // Call fetchSharedCasefilesFromRemote() on that keeper with the
+        // remote name:
+        await keeper.gitOps.fetchSharedCasefilesFromRemote(peer.remote);
+
+        // Call getListOfCasefiles() on that keeper and store the
+        // result as *knownCasefiles* in the sharing state (i.e. this._services.setSharingState(...))
+        await this._modifySharingState(async (state) => {
+            state.knownCasefiles = await keeper.gitOps.getListOfCasefiles();
+            return true;
+        });
+
+        // Signal that the tree data has changed
+        this._stateChange.fire();
+    }
+
+    async includeAuthors(instance: CasefileInstanceMetadata): Promise<void> {
+        if (!this.peer) {
+            console.error(
+                "code-casefile: Cannot look up authors if no peer selected"
+            );
+            return;
+        }
+
+        // It would be possible to get authors using all keepers in parallel,
+        // but this is complicated because each keeper will return the authors
+        // it finds in order of modification, with most recent first.  This
+        // ordering is important.
+        const keeper = await this._getCurrentKeeper({
+            folder: this.peer.folder,
+        });
+        if (!keeper) {
+            return;
+        }
+
+        const { authors } = await keeper.gitOps.getCasefileAuthors(
+            instance.path
+        );
+        instance.authors = authors;
+    }
+
+    private _getCurrentKeeper(options: {
+        folder: string,
+    }): CasefileKeeper | undefined {
+        // Look through the casefile keepers to find *peer.folder*:
+        debug(
+            "Working directories of keepers: %O",
+            this._services.casefile.keepers.map(
+                (keeper) => keeper.workingDir
+            )
+        );
+        const keeper = this._services.casefile.keepers.find(
+            (item) => item.workingDir === options.folder
+        );
+        if (!keeper) {
+            console.error("code-casefile: Unable to locate casefile keeper for %s", options.folder);
+            return;
+        }
+        return keeper;
+    }
+}
+
+/**
+ * @summary Count the number of workspace folders with a given basename
+ * @param folderName Basename to count in workspaceFolders
+ * @returns Count of folders with the basename *folderName*
+ */
+function workspaceFolderBasenameCount(folderName: string): number {
+    const { workspaceFolders } = vscode.workspace;
+    if (!workspaceFolders) {
+        return 0;
+    }
+    return workspaceFolders.reduce(
+        (prevCount, { uri }) => prevCount + (
+            basename(uri.fsPath) === folderName
+            ? 1
+            : 0
+        ),
+        0
+    );
+}

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -1,0 +1,3 @@
+export function deiconed(s: string): string {
+    return s.replace(/\$\(.*?\)/, '\\$&');
+}

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -1,3 +1,22 @@
+import * as vscode from "vscode";
+
 export function deiconed(s: string): string {
     return s.replace(/\$\(.*?\)/, '\\$&');
+}
+
+type SetContextOptions = {
+    prefix?: string | false;
+};
+
+export function setContext(
+    key: string,
+    value: any,
+    {
+        prefix = 'codeCasefile'
+    }: SetContextOptions = {}
+): Thenable<void> {
+    if (prefix !== false) {
+        key = `${prefix}.${key}`;
+    }
+    return vscode.commands.executeCommand('setContext', key, value);
 }


### PR DESCRIPTION
This implementation allows selection of the sharing peer (local Git repository and remote name) from a "quick pick".

Resolves #6 